### PR TITLE
Replace lockfree with lock_freedom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 # Lock-free data structures
-lockfree = { version = "0.5", optional = true }
+lockfree = { package = "lock_freedom", version = "0.1.1", optional = true }
 
 # SIMD and vectorization
 packed_simd_2 = { version = "0.3", optional = true }

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -500,7 +500,7 @@ async-trait = "0.1"
 ```toml
 crossbeam-queue = "0.3"
 crossbeam-utils = "0.8"
-lockfree = "0.5"
+lock_freedom = "0.1"
 ```
 
 ### SIMD & Performance


### PR DESCRIPTION
c.f. https://github.com/rustsec/advisory-db/pull/2461

Note I wasnt able to compile on either my macos intel or linux intel, even when trying to disable features and only enable the lockfree feature.  I can write up issues about these if you would find that useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency for lock-free structures functionality, including version adjustments and corresponding documentation updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->